### PR TITLE
replicate favicon

### DIFF
--- a/routes/favicon.coffee
+++ b/routes/favicon.coffee
@@ -1,0 +1,23 @@
+request = require 'request'
+fs = require 'fs'
+os = require 'os'
+path = require 'path'
+CACHEFILE = 'favicon.ico'
+
+module.exports = (req, res, next) ->
+	res.sendFile CACHEFILE, root: os.tmpdir(), (error) ->
+		return unless error?
+		request "https://vine.co/", (error, response, body) ->
+			return next error if error?
+			unless response.statusCode is 200
+				error = new Error "Unexpected response code #{response.statusCode} while getting vine.co homepage"
+				error.status = 500
+				return next error
+			request (/https:\/\/[^"]*?favicon\.ico/.exec body)[0]
+				.on 'error', (error) ->
+					error = new Error "Could not retrieve favicon"
+					error.status = 500
+					return next error
+				.on 'end', () ->
+					res.sendFile CACHEFILE, root: os.tmpdir()
+				.pipe fs.createWriteStream path.join os.tmpdir(), CACHEFILE

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -2,5 +2,6 @@ express = require 'express'
 router = express.Router()
 
 router.get /^\/users\/(\d+)\/(atom|rss)$/, require './users'
+router.get /\/favicon\.ico$/, require './favicon'
 
 module.exports = router


### PR DESCRIPTION
Newsreaders may request the icon as a symbol for the feed. Web browsers usually ask for it as well. Instead of producing an error in this case, this patch provides them with the possibly cached icon parsed from the vine homepage.
