### PR TITLE
support systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,21 @@ Setting up
 
 1. Clone repository
 2. Install dependencies with `npm install`
-3. Start server with `bin/www` (or use Forever or similar)
+3. Start server with `bin/www` (or use Forever or similar), or [configure systemd to start it automatically](#Usage-with-systemd)
 4. Go to `localhost:3000/users/<vine-user-id>/atom` or 
    `localhost:3000/users/<vine-user-id>/rss`
+
+Usage with systemd
+------------------
+
+1. Globally install vinefeed with `npm install -g`
+2. Copy or link `vinefeed.service` and `vinefeed.socket`
+   to a systemd units directory,
+    e.g. `/usr/lib/systemd/system` or `~/.config/systemd/user`
+3. Start them via `systemctl start vinefeed.socket`
+4. Go to `localhost:3000/users/<vine-user-id>/atom` or
+   `localhost:3000/users/<vine-user-id>/rss`
+5. To permanently enable the service, execute `systemctl enable vinefeed.socket`
 
 To do
 -----

--- a/bin/www
+++ b/bin/www
@@ -13,5 +13,5 @@ app.set 'port', process.env.PORT
 
 console.log "Environment: #{app.get('env')}"
 
-server = app.listen app.get('port'), ->
+server = app.listen require('systemd-socket')() || app.get('port'), ->
 	console.log "Listening on port #{server.address().port}"

--- a/bin/www
+++ b/bin/www
@@ -1,5 +1,10 @@
 #!/usr/bin/env coffee
 
+try
+	systemdsocket = require 'systemd-socket'
+catch e
+	systemdsocket = -> null
+
 process.chdir __dirname
 
 argv = require('minimist') process.argv.slice(2),
@@ -13,5 +18,5 @@ app.set 'port', process.env.PORT
 
 console.log "Environment: #{app.get('env')}"
 
-server = app.listen require('systemd-socket')() || app.get('port'), ->
+server = app.listen systemdsocket() || app.get('port'), ->
 	console.log "Listening on port #{server.address().port}"

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "morgan": "^1.3.2",
     "request": "^2.45.0",
     "systemd-socket": "^0.0.0"
+  },
+  "bin": {
+    "vinefeed": "bin/www"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "feed": "^0.2.6",
     "minimist": "^1.1.0",
     "morgan": "^1.3.2",
-    "request": "^2.45.0",
+    "request": "^2.45.0"
+  },
+  "optionalDependencies": {
     "systemd-socket": "^0.0.0"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "feed": "^0.2.6",
     "minimist": "^1.1.0",
     "morgan": "^1.3.2",
-    "request": "^2.45.0"
+    "request": "^2.45.0",
+    "systemd-socket": "^0.0.0"
   }
 }

--- a/vinefeed.service
+++ b/vinefeed.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Vine Atom feed HTTP server
+
+[Service]
+Environment=NODE_ENV=production
+ExecStart=/usr/bin/vinefeed
+
+[Install]
+WantedBy=multi-user.target

--- a/vinefeed.socket
+++ b/vinefeed.socket
@@ -1,0 +1,5 @@
+[Socket]
+ListenStream=3000
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
While [packaging this module for Arch Linux](https://aur.archlinux.org/packages/nodejs-vinefeed/), I made vinefeed play nicely with systemd. Incorporation of these changes here will make users of other distributions benefit, too.

This pull request provides unit files to start it as a system or user service and adds a few lines on how to use them to the `README`. Socket activation is also supported so that the program will only be started up when its port is accessed.
