### PR TITLE
Redirect to favicon

### DIFF
--- a/routes/favicon.coffee
+++ b/routes/favicon.coffee
@@ -1,0 +1,16 @@
+request = require 'request'
+
+url = null
+
+module.exports = (req, res, next) ->
+	if url?
+		res.redirect 301, url
+		return
+	request "https://vine.co/", (error, response, body) ->
+		return next error if error?
+		unless response.statusCode is 200
+			error = new Error "Unexpected response code #{response.statusCode} while getting vine.co homepage"
+			error.status = 500
+			return next error
+		url = /\bhttps:\/\/[^"]*?favicon\.ico\b/.exec(body)[0]
+		res.redirect 301, url

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -2,5 +2,6 @@ express = require 'express'
 router = express.Router()
 
 router.get /^\/users\/(\d+)\/(atom|rss)$/, require './users'
+router.get /\/favicon\.ico$/, require './favicon'
 
 module.exports = router


### PR DESCRIPTION
This is a more efficient variant of pull request #1 that redirects to the original favicon location instead of caching it locally, reducing memory consumption on both vinefeed server and a client that already knows vine.
