### PR TITLE
Query profiles

### DIFF
--- a/routes/users.coffee
+++ b/routes/users.coffee
@@ -19,39 +19,47 @@ module.exports = (req, res, next) ->
 				return next error
 			return handler body.data
 
-	request "https://vine.co/api/users/profiles/#{user}", guard "querying profile", (profile) ->
-		feed = new Feed
-			title: "Vines by #{profile.username}"
-			description: profile.description
-			link: "https://vine.co/u/#{profile.userId}"
-			image: profile.avatarUrl
+	feed = new Feed {}
 
-		request "https://vine.co/api/timelines/users/#{user}", guard "retrieving posts", (timeline) ->
-			for record in timeline.records
-				id = record.permalinkUrl.replace /.*\//, ''
-				feed.addItem
-					title: record.description
-					link: record.permalinkUrl
-					description: """
-						<iframe
-								class="vine-embed"
-								src="https://vine.co/v/#{id}/embed/postcard?related=0"
-								width="600"
-								height="600"
-								frameborder="0"></iframe>
-						<div>
-							<small>
-								<a href="#{record.videoUrl}">Direct link to video</a>
-							</small>
-						</div>
-					"""
-					date: new Date record.created
-					image: record.thumbnailUrl
-					author: [
-						name: record.username
-						link: "https://vine.co/u/#{record.userId}"
-					]
-
+	finish = () ->
+		console.log feed.finished
+		if feed.finished
 			payload = feed.render if format is 'atom' then 'atom-1.0' else 'rss-2.0'
 			res.set 'Content-Type': if format is 'atom' then 'application/atom+xml' else 'application/rss+xml'
 			res.send payload
+		else
+			feed.finished = true
+
+	request "https://vine.co/api/users/profiles/#{user}", guard "querying profile", (profile) ->
+		feed.title = "Vines by #{profile.username}"
+		feed.description = profile.description
+		feed.link = "https://vine.co/u/#{profile.userId}"
+		feed.image = profile.avatarUrl
+		finish()
+
+	request "https://vine.co/api/timelines/users/#{user}", guard "retrieving posts", (timeline) ->
+		for record in timeline.records
+			id = record.permalinkUrl.replace /.*\//, ''
+			feed.addItem
+				title: record.description
+				link: record.permalinkUrl
+				description: """
+					<iframe
+							class="vine-embed"
+							src="https://vine.co/v/#{id}/embed/postcard?related=0"
+							width="600"
+							height="600"
+							frameborder="0"></iframe>
+					<div>
+						<small>
+							<a href="#{record.videoUrl}">Direct link to video</a>
+						</small>
+					</div>
+				"""
+				date: new Date record.created
+				image: record.thumbnailUrl
+				author: [
+					name: record.username
+					link: "https://vine.co/u/#{record.userId}"
+				]
+		finish()

--- a/routes/users.coffee
+++ b/routes/users.coffee
@@ -20,7 +20,7 @@ module.exports = (req, res, next) ->
 		profile = body.data
 		feed = new Feed
 			title: "Vines by #{profile.username}"
-			description: "" # Required in RSS
+			description: profile.description
 			link: "https://vine.co/u/#{profile.userId}"
 			image: profile.avatarUrl
 

--- a/routes/users.coffee
+++ b/routes/users.coffee
@@ -5,52 +5,62 @@ module.exports = (req, res, next) ->
 	user = req.params[0]
 	format = req.params[1]
 
-	request "https://vine.co/api/timelines/users/#{user}", (error, response, body) ->
+	request "https://vine.co/api/users/profiles/#{user}", (error, response, body) ->
 		return next error if error?
 		unless response.statusCode is 200
-			error = new Error "Unexpected response code #{response.statusCode} from vine.co"
+			error = new Error "Unexpected response code #{response.statusCode} while querying profile"
 			error.status = 500
 			return next error
 		body = JSON.parse body
 		if not body.success or body.error
-			error = new Error "Error from vine.co. Code: '#{body.code}', message '#{body.error}'"
+			error = new Error "Error retrieving profile. Code: '#{body.code}', message '#{body.error}'"
 			error.status = 500
 			return next error
-		records = body.data.records
-		author = if records.length then records[0].username else "user #{user}"
-		link = "https://vine.co/u/#{user}"
 
+		profile = body.data
 		feed = new Feed
-			title: "Vines by #{author}"
+			title: "Vines by #{profile.username}"
 			description: "" # Required in RSS
-			link: link
-			image: if records.length then records[0].avatarUrl else undefined
+			link: "https://vine.co/u/#{profile.userId}"
+			image: profile.avatarUrl
 
-		for record in records
-			id = record.permalinkUrl.replace /.*\//, ''
-			feed.addItem
-				title: record.description
-				link: record.permalinkUrl
-				description: """
-					<iframe
-							class="vine-embed"
-							src="https://vine.co/v/#{id}/embed/postcard?related=0"
-							width="600"
-							height="600"
-							frameborder="0"></iframe>
-					<div>
-						<small>
-							<a href="#{record.videoUrl}">Direct link to video</a>
-						</small>
-					</div>
-				"""
-				date: new Date record.created
-				image: record.thumbnailUrl
-				author: [
-					name: author
-					link: link
-				]
+		request "https://vine.co/api/timelines/users/#{user}", (error, response, body) ->
+			return next error if error?
+			unless response.statusCode is 200
+				error = new Error "Unexpected response code #{response.statusCode} from vine.co"
+				error.status = 500
+				return next error
+			body = JSON.parse body
+			if not body.success or body.error
+				error = new Error "Error from vine.co. Code: '#{body.code}', message '#{body.error}'"
+				error.status = 500
+				return next error
 
-		payload = feed.render if format is 'atom' then 'atom-1.0' else 'rss-2.0'
-		res.set 'Content-Type': if format is 'atom' then 'application/atom+xml' else 'application/rss+xml'
-		res.send payload
+			for record in body.data.records
+				id = record.permalinkUrl.replace /.*\//, ''
+				feed.addItem
+					title: record.description
+					link: record.permalinkUrl
+					description: """
+						<iframe
+								class="vine-embed"
+								src="https://vine.co/v/#{id}/embed/postcard?related=0"
+								width="600"
+								height="600"
+								frameborder="0"></iframe>
+						<div>
+							<small>
+								<a href="#{record.videoUrl}">Direct link to video</a>
+							</small>
+						</div>
+					"""
+					date: new Date record.created
+					image: record.thumbnailUrl
+					author: [
+						name: record.username
+						link: "https://vine.co/u/#{record.userId}"
+					]
+
+			payload = feed.render if format is 'atom' then 'atom-1.0' else 'rss-2.0'
+			res.set 'Content-Type': if format is 'atom' then 'application/atom+xml' else 'application/rss+xml'
+			res.send payload


### PR DESCRIPTION
While using the changes from pull request #2 in practice, I noticed that authors were not always assigned correctly. Because Vine supports reposting, videos of other authors may appear in the examined timeline. So guessing the author of the whole feed from any entry is always prone to fail.

This pull request improves on that by first looking at the profile of the requested ID to collect information concerning the whole feed, Only afterwards it processes the timeline, assigning individual authorship to each posting.

For the cost of the additional request to the profile, the feed can then carry the original description now readily available there.
